### PR TITLE
Load remote fonts from the URL’s query string

### DIFF
--- a/src/components/FontLoader.vue
+++ b/src/components/FontLoader.vue
@@ -241,11 +241,21 @@ export default {
       }
     },
 
+    getQueryStringFontUrls() {
+      const urls = this.$route.query.preload || [];
+      return Array.isArray(urls) ? urls : [urls];
+    },
+
+    getDefaultFontUrls() {
+      const dir = (process.env.BASE_URL + "/fonts/").replace(/\/+/g, "/");
+      return DEFAULT_FONTS.map(f => dir + f);
+    },
+
     loadDefaultFonts() {
       this.defaultFontsLoaded = true;
-      const dir = (process.env.BASE_URL + "/fonts/").replace(/\/+/g, "/");
-      const fonts = DEFAULT_FONTS;
-      this.loadFonts({ urls: fonts.map(f => dir + f) });
+      let urls = this.getQueryStringFontUrls();
+      if (!urls.length) urls = this.getDefaultFontUrls();
+      this.loadFonts({ urls });
     },
 
     onFilesDropped(files) {

--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ import Home from "@/views/Home.vue";
 import Help from "@/views/Help.vue";
 import KerningHelp from "@/views/KerningHelp.vue";
 import AnimationHelp from "@/views/AnimationHelp.vue";
+import QueryString from "@/views/QueryString.vue";
 import FontTester from "@/views/FontTester.vue";
 
 import textKinds from "@/models/textKinds";
@@ -52,6 +53,15 @@ const router = new Router({
       components: {
         header: SiteHeader,
         main: AnimationHelp,
+        footer: SiteFooter,
+      },
+    },
+    {
+      path: "/help/query-string",
+      name: "QueryString",
+      components: {
+        header: SiteHeader,
+        main: QueryString,
         footer: SiteFooter,
       },
     },

--- a/src/views/Help.md
+++ b/src/views/Help.md
@@ -2,3 +2,4 @@
 
 [Kerning](/help/kerning)
 [Animation](/help/animation)
+[Preloading custom fonts](/help/query-string)

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -10,6 +10,9 @@
           <li>
             <router-link :to="`/help/kerning`">Kerning string editor</router-link>
           </li>
+          <li>
+            <router-link :to="`/help/query-string`">Preloading custom fonts</router-link>
+          </li>
         </ol>
       </div>
     </div>

--- a/src/views/QueryString.md
+++ b/src/views/QueryString.md
@@ -1,0 +1,21 @@
+Parameters in the URL query string can be used to load custom fonts hosted elsewhere online and then share the result with others. For example, <a href="/glyphs?preload=/fonts/Rywalka-Regular.ttf" target="_blank">here’s the glyphs tab with Rywalka loaded</a> (opens in a new tab).
+
+To do this, add a `preload` query parameter with the URL of your font file, for example `?preload=https://example.com/Font.ttf`, to the end of the page URL.
+
+You can even add multiple files by separating each parameter with `&`, for example `?preload=URL1&preload=URL2&preload=URL3`.
+
+When preloading mutliple font URLs, you can set an additional `f` parameter with the name of the font to display by default. The other fonts will be available from the drop-down fonts menu. Here’s a full example:
+
+```
+https://bulletproof.italic.space/ABCs?preload=https://bulletproof.italic.space/fonts/Rywalka-
+Regular.ttf&preload=https://bulletproof.italic.space/fonts/Graduate.ttf&f=Rywalka
+```
+
+This will open the ABCs tab, preload Rywalka and Graduate to the fonts menu, and set Rywalka as the initially displayed font.
+
+---
+
+### Notes
+
+- Your font must be served over HTTPS, otherwise it will fail to load.
+- Currently Bulletproof supports loading TTF, OTF, and WOFF font files, but not WOFF2.

--- a/src/views/QueryString.vue
+++ b/src/views/QueryString.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="help-topic">
+    <div class="help">
+      <div class="reading">
+        <h2 class="help-heading">
+          <router-link :to="`/help`">Help / </router-link>Preloading custom fonts
+        </h2>
+        <QueryString />
+      </div>
+    </div>
+    <div class="example"/>
+  </div>
+</template>
+
+<script>
+import QueryString from "./QueryString.md";
+
+export default {
+  components: {
+    QueryString,
+  },
+}
+</script>

--- a/src/views/Welcome.md
+++ b/src/views/Welcome.md
@@ -29,3 +29,7 @@ The app is equipped with a <router-link to="/kerning">kerning string generator</
 ## Playground & Animation
 
 Any open text sample can be edited. In the <router-link to="/editor">editor tab</router-link> some more options are available: setting bold and italic (with separately selectable fonts), as well as taking snapshots of the settings and using them as animation keyframes — can be useful for recording gifs or videos, or toggling multiple features on and off more quickly. <router-link to="/help/animation">[See animation editor help]</router-link>
+
+## Preload a remote font
+
+If you want to share a link to a specific tab and automatically load a remote font, you can add a query parameter with the URL of your font file — like `?preload=https://example.com/Font.ttf` — to the end of the page URL. <router-link to="/help/query-string">[See preloading custom fonts help]</router-link>


### PR DESCRIPTION
The [Samsa web app](https://github.com/Lorp/samsa) has a nice feature where you can preload a font by setting it in the URL’s query string and I thought it would be cool to have the same feature on Bulletproof, so a designer can provide a link directly to a Bulletproof test tab with their font loaded.

This PR allows loading remote fonts via URLs in the query string, e.g. `/ABCs?preload=https://www.example.com/Font.ttf`. It also supports multiple `preload` parameters. Each will be available in the font drop-down menu and the initially selected font can be set using the `f` parameter like for the default fonts currently, e.g. `/glyphs?preload=FONT_A_URL&preload=FONT_B_URL&f=FONT_A_NAME`. What do you think?

Some considerations:

- Remote fonts must be served over HTTPS, otherwise loading will fail.
- There could be some UI to do this too, e.g. a link icon next to the upload button that allowed input for a font URL.
- I haven’t added any documentation for this yet, as I noticed the `f` parameter was also undocumented, but would happily add some.
- Because this uses the same code as the default font loading (basically replacing the default fonts with the fonts set in the query string), it only loads the fonts when the page first loads — you can’t navigate between fonts like this within the app.